### PR TITLE
Use nullptr keyword instead of 0 for a null pointer

### DIFF
--- a/eyeguard/src/eyeguard.cpp
+++ b/eyeguard/src/eyeguard.cpp
@@ -3,7 +3,7 @@
 
 /**
  * @brief Constructor for the main window of the EyeGuard tool.
- * @param parent Parent widget, usually NULL
+ * @param parent Parent widget, usually nullptr
  *
  * Creates the main window of the EyeGuard tool. It contains the sliders
  * used to specify the warning timeout, the buttons for about dialog,
@@ -18,7 +18,7 @@ EyeGuard::EyeGuard (QWidget * parent):
     setWindowTitle (tr ("EyeGuard v") + tr (VERSION_STRING));
 
     p_TitleLabel = new QLabel (tr ("EyeGuard"));
-    p_TrayIcon = 0;
+    p_TrayIcon = nullptr;
 
     p_SliderGroup = new QGroupBox (tr ("Options"), this);
 

--- a/eyeguard/src/eyeguard.h
+++ b/eyeguard/src/eyeguard.h
@@ -13,7 +13,7 @@ class EyeGuard: public QWidget
     Q_OBJECT
 
 public:
-    EyeGuard (QWidget * parent = 0);
+    EyeGuard (QWidget * parent = nullptr);
 
     ~EyeGuard ();
 

--- a/eyeguard/src/settingsdialog.h
+++ b/eyeguard/src/settingsdialog.h
@@ -14,7 +14,7 @@ class SettingsDialog: public QDialog {
     Q_OBJECT
 
 public:
-    SettingsDialog (QWidget * parent = 0);
+    SettingsDialog (QWidget * parent = nullptr);
     ~SettingsDialog ();
 
 public:


### PR DESCRIPTION
Minor changes, mostly in header files, replace `MyWidget(QWidget * parent = 0)` with `MyWidget(QWidget * parent = nullptr)`. Also use nullptr keyword for null pointer in other places whereever necessary.